### PR TITLE
Switch to Preact for Production builds

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint
+yarn build

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ jambonz
 
 ![](/public/jambonz.png)
 
+## Stack
+
+This is a [Next.js](https://nextjs.org) application using [Preact](https://preactjs.com/) for Production builds which reduces JavaScript payload sizes by more than half for deployments! We're using a model that only uses Preact when generating the Production builds from this article [here](https://darrenwhite.dev/blog/nextjs-replace-react-with-preact).
+
 ## Deploy targets
 
 This app can easily be deployed to multiple targets including Vercel, Netlify or AWS+circleci.

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,15 @@
 module.exports = {
   trailingSlash: true,
+  webpack: (config, { dev, isServer }) => {
+    // Replace React with Preact only in client production build
+    if (!dev && !isServer) {
+      Object.assign(config.resolve.alias, {
+        react: 'preact/compat',
+        'react-dom/test-utils': 'preact/test-utils',
+        'react-dom': 'preact/compat',
+      });
+    }
+  
+    return config;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "classnames": "^2.2.6",
     "nanoid": "^3.1.22",
     "next": "^10.0.8-canary.9",
+    "preact": "^10.5.13",
     "prismjs": "^1.23.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,6 +2209,11 @@ postcss@^7.0.32:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+preact@^10.5.13:
+  version "10.5.13"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"
+  integrity sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"


### PR DESCRIPTION
This PR implements Preact for Production builds. It also updates the Husky `pre-commit` hook to run `yarn build` rather than just `yarn lint`. This ensures we don't introduce anything that will fail a Next.js build into source code and the `prebuild` command runs `lint` so we get both checks by making this change.

This is different than other models of using Preact with Next.js, such as the example by [@developit](https://github.com/developit) [here](https://github.com/developit/nextjs-preact-demo). This model is for Preact on the client ONLY. We don't integrate Preact with `SSR` since we're only interested in optimizing our client application for users.

Optionally, we could run Preact all the time in development as well by removing the `!dev` condition in our `next.config.js` file that looks like this:

```js
module.exports = {
  trailingSlash: true,
  webpack: (config, { dev, isServer }) => {
    // Replace React with Preact only in client production build
    if (!dev && !isServer) {
      Object.assign(config.resolve.alias, {
        react: 'preact/compat',
        'react-dom/test-utils': 'preact/test-utils',
        'react-dom': 'preact/compat',
      });
    }
  
    return config;
  },
};
```

Our savings are pretty good. We have a lightweight app overall, but these are still great numbers:

Before (with React):
<img width="443" alt="Screen Shot 2021-06-10 at 8 17 33 AM" src="https://user-images.githubusercontent.com/438711/121551960-ebb1c080-c9c4-11eb-9d25-379692a296d7.png">

After (with Preact):
<img width="444" alt="Screen Shot 2021-06-10 at 8 17 09 AM" src="https://user-images.githubusercontent.com/438711/121552000-f4a29200-c9c4-11eb-84a7-823eb7adc587.png">
