### PR TITLE
Fix bug where docs submenu items with same slug get active state

### DIFF
--- a/pages/docs/[[...slug]].js
+++ b/pages/docs/[[...slug]].js
@@ -57,7 +57,7 @@ function Sidebar({data}) {
               </div>
               <ul className={classNames(subClasses)}>
                 {item.pages.map((page) => {
-                  const isActiveItem = (parsedPath === page.path);
+                  const isActiveItem = (parsedPath === page.path && parsedTab === item.path) && isActiveToggle;
                   const itemClasses = {
                     'ms': true,
                     'active': isActiveItem,


### PR DESCRIPTION
This fixes a UI bug I found where sub-menu items in the Docs section would activate all items with the same slug under every tab. Examples were `nodejs-sdk` slug and the `overview` slug.

<img width="914" alt="Screen Shot 2021-06-10 at 5 20 12 PM" src="https://user-images.githubusercontent.com/438711/121613032-8388cc00-ca10-11eb-96d6-3d779bf35b51.png">
