### PR TITLE
Fix bug with regex matching active navi link for mobile and style mobile active navi link

### DIFF
--- a/components/navi.js
+++ b/components/navi.js
@@ -9,10 +9,12 @@ import { Button, Icon, useMobileMedia } from './jambonz-ui';
 
 function NaviItem({obj}) {
   const router = useRouter();
-  const regex = new RegExp(`^${obj.link}`);
+  const rSlash = /^\/|\/$/g;
+  const cleanLink = obj.link.replace(rSlash, '');
+  const cleanPath = router.asPath.replace(rSlash, '');
   const classes = {
     navi__link: true,
-    active: regex.test(router.asPath),
+    active: cleanLink === cleanPath,
   };
 
   return (

--- a/styles/_navi.scss
+++ b/styles/_navi.scss
@@ -98,10 +98,6 @@
       text-align: center;
       padding-top: 32px;
 
-      li {
-        margin-top: 16px;
-      }
-
       .navi__link {
         color: $white;
         font-size: $h6-size;
@@ -110,8 +106,24 @@
       }
     }
 
+    &__links {
+      .navi__link {
+        padding: 4px 0;
+        margin: 12px 0;
+        display: inline-block;
+
+        &.active {
+          border-bottom: 2px solid $white;
+        }
+      }
+    }
+
     &__footer {
       padding-top: 48px;
+
+      li {
+        margin-top: 16px;
+      }
 
       .navi__link {
         font-size: $m-size;


### PR DESCRIPTION
This PR fixes a basically unseen bug wherein the `Home` navigation link was receiving that `active` className for every page due to a bad dynamic regex: `/^\//` when looking at the `Home` link URL, which is just `/`.

This bug was found by myself because I decided I wanted to add an active navigation link state to the mobile navigation. So, this PR also includes the new styles for that.

So that looks like this now:

<img width="584" alt="Screen Shot 2021-06-17 at 6 29 11 PM" src="https://user-images.githubusercontent.com/438711/122492066-f6a6bb00-cf99-11eb-8938-0b683d7dff38.png">
