### PR TITLE
Tweak mobile navi top padding to correlate to top banner presence

### DIFF
--- a/styles/_layout.scss
+++ b/styles/_layout.scss
@@ -50,6 +50,13 @@
   @media (max-width: $width-mobile) {
     @include mxs();
   }
+
+  // Effects .navi @see _navi.scss
+  & + .navi {
+    .navi__mobile {
+      padding-top: 32px;
+    }
+  }
 }
 
 .latest {


### PR DESCRIPTION
Adds top padding to mobile navi when the top banner is present on the page so the overlapping UI elements are aligned (makes the transition not feel jarring). Screenshot with opacity to see the change.

<img width="705" alt="Screen Shot 2021-07-22 at 2 06 48 PM" src="https://user-images.githubusercontent.com/438711/126709760-76d993b9-3923-4b75-bd1a-0e3656a84c09.png">
