### PR TITLE
Better mobile styling for top banner

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -6,9 +6,11 @@ import Footer from './footer';
 
 function Banner({ data }) {
   return (
-    <Link href={data.link}>
-      <a target="_blank" className="banner">{data.text}</a>
-    </Link>
+    <div className="banner">
+      <Link href={data.link}>
+        <a target="_blank" className="wrap">{data.text}</a>
+      </Link>
+    </div>
   );
 }
 

--- a/data/site.yml
+++ b/data/site.yml
@@ -11,10 +11,10 @@ latest:
       - Sign up <a href="https://jambonz.us/register" target="_blank">here</a> for your free development account,
       - and <a href="https://www.telecomsxchange.com/jambonz" target="_blank">visit our partner TelecomXChange</a> for $20 free credit!
   -
-      active: false
-      label: econnect
-      headline: jambonz will be at Enterprise Connect 2021
-      subtext: Ping us at <a href="mailto:sales@jambonz.org" target="_blank">sales@jambonz.org</a> to set up a meeting!
+    active: false
+    label: econnect
+    headline: jambonz will be at Enterprise Connect 2021
+    subtext: Ping us at <a href="mailto:sales@jambonz.org" target="_blank">sales@jambonz.org</a> to set up a meeting!
   -
     active: true
     label: aws

--- a/styles/_layout.scss
+++ b/styles/_layout.scss
@@ -36,19 +36,26 @@
 *******************************************************************************/
 .banner {
   @include flex-cols();
-  @include ms();
   justify-content: center;
   width: 100%;
   height: 32px;
-  color: $white;
   background: $jambonz;
-  font-family: $font-medium;
   position: sticky;
   top: 0;
   z-index: $navi-index + 1;
+  text-align: center;
 
-  @media (max-width: $width-mobile) {
-    @include mxs();
+  a {
+    @include ms();
+    color: $white;
+    font-family: $font-medium;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    @media (max-width: $width-mobile) {
+      @include mxs();
+    }
   }
 
   // Effects .navi @see _navi.scss


### PR DESCRIPTION
Going from this on mobile with long text in banner:
![IMG_1174](https://user-images.githubusercontent.com/438711/145611858-f5b3b563-eada-42b1-9d33-ac76b5a207e3.jpg)

To this on mobile with long text in banner:

<img width="409" alt="Screen Shot 2021-12-10 at 8 55 12 AM" src="https://user-images.githubusercontent.com/438711/145611907-81de7821-b3d4-4389-a378-5b37862ec086.png">

